### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 MCP server for [Awesome-llms-txt](https://github.com/SecretiveShell/Awesome-llms-txt). Add documentation directly into your conversation via mcp resources.
 
+<a href="https://glama.ai/mcp/servers/kqwhhpe8l7"><img width="380" height="200" src="https://glama.ai/mcp/servers/kqwhhpe8l7/badge" alt="MCP-llms-txt MCP server" /></a>
+
 ## Installation
 
 ### Installing via Smithery


### PR DESCRIPTION
This PR adds a badge for the [MCP-llms-txt](https://glama.ai/mcp/servers/kqwhhpe8l7) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/kqwhhpe8l7"><img width="380" height="200" src="https://glama.ai/mcp/servers/kqwhhpe8l7/badge" alt="MCP-llms-txt MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.